### PR TITLE
Implement VL53L4CX platform layer and basic ranging loop

### DIFF
--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -21,7 +21,8 @@
 
 /* Private includes ----------------------------------------------------------*/
 /* USER CODE BEGIN Includes */
-
+#include "vl53lx_api.h"
+#include <stdio.h>
 /* USER CODE END Includes */
 
 /* Private typedef -----------------------------------------------------------*/
@@ -45,7 +46,9 @@ I2C_HandleTypeDef hi2c1;
 UART_HandleTypeDef huart2;
 
 /* USER CODE BEGIN PV */
-
+VL53LX_Dev_t vl53lx_dev;
+VL53LX_MultiRangingData_t vl53lx_data;
+VL53LX_Error vl53lx_status;
 /* USER CODE END PV */
 
 /* Private function prototypes -----------------------------------------------*/
@@ -59,7 +62,11 @@ static void MX_I2C1_Init(void);
 
 /* Private user code ---------------------------------------------------------*/
 /* USER CODE BEGIN 0 */
-
+int __io_putchar(int ch)
+{
+  HAL_UART_Transmit(&huart2, (uint8_t *)&ch, 1, HAL_MAX_DELAY);
+  return ch;
+}
 /* USER CODE END 0 */
 
 /**
@@ -94,21 +101,30 @@ int main(void)
   MX_USART2_UART_Init();
   MX_I2C1_Init();
   /* USER CODE BEGIN 2 */
-
+  vl53lx_dev.i2c_slave_address = 0x52;
+  vl53lx_dev.comms_speed_khz = 400;
+  vl53lx_dev.comms_type = 1;
+  vl53lx_status = VL53LX_WaitDeviceBooted(&vl53lx_dev);
+  vl53lx_status = VL53LX_DataInit(&vl53lx_dev);
+  vl53lx_status = VL53LX_StartMeasurement(&vl53lx_dev);
   /* USER CODE END 2 */
 
   /* Infinite loop */
   /* USER CODE BEGIN WHILE */
   while (1)
-  {
-    /* USER CODE END WHILE */
+    {
+      /* USER CODE END WHILE */
 
-    /* USER CODE BEGIN 3 */
-  }
-  /* USER CODE END 3 */
-}
+      /* USER CODE BEGIN 3 */
+        VL53LX_WaitMeasurementDataReady(&vl53lx_dev);
+        VL53LX_GetMultiRangingData(&vl53lx_dev, &vl53lx_data);
+        printf("Distance: %d mm\r\n", vl53lx_data.RangeData[0].RangeMilliMeter);
+        VL53LX_ClearInterruptAndStartMeasurement(&vl53lx_dev);
+        HAL_Delay(100);
+      }
+    /* USER CODE END 3 */
 
-/**
+  /**
   * @brief System Clock Configuration
   * @retval None
   */

--- a/Drivers/VL53L4CX_BareDriver_1.2.14/BareDriver/platform/src/vl53lx_platform.c
+++ b/Drivers/VL53L4CX_BareDriver_1.2.14/BareDriver/platform/src/vl53lx_platform.c
@@ -21,6 +21,9 @@
 
 #include "vl53lx_platform.h"
 #include <vl53lx_platform_log.h>
+#include "main.h"
+
+extern I2C_HandleTypeDef hi2c1;
 
 
 
@@ -36,48 +39,56 @@
 
 
 VL53LX_Error VL53LX_CommsInitialise(
-	VL53LX_Dev_t *pdev,
-	uint8_t       comms_type,
-	uint16_t      comms_speed_khz)
+        VL53LX_Dev_t *pdev,
+        uint8_t       comms_type,
+        uint16_t      comms_speed_khz)
 {
-	VL53LX_Error status = 255;
-	/* To be filled by customer according to the platform request. Return 0 if OK */
-	return status;
+        VL53LX_Error status = VL53LX_ERROR_NONE;
+        pdev->comms_type = comms_type;
+        pdev->comms_speed_khz = comms_speed_khz;
+        return status;
 
 }
 
 
 VL53LX_Error VL53LX_CommsClose(
-	VL53LX_Dev_t *pdev)
+        VL53LX_Dev_t *pdev)
 {
-	VL53LX_Error status = 255;
-	/* To be filled by customer according to the platform request. Return 0 if OK */
-	return status;
+        VL53LX_Error status = VL53LX_ERROR_NONE;
+        return status;
 }
 
 
 
 VL53LX_Error VL53LX_WriteMulti(
-	VL53LX_Dev_t *pdev,
-	uint16_t      index,
-	uint8_t      *pdata,
-	uint32_t      count)
+        VL53LX_Dev_t *pdev,
+        uint16_t      index,
+        uint8_t      *pdata,
+        uint32_t      count)
 {
-	VL53LX_Error status = 255;
-	/* To be filled by customer according to the platform request. Return 0 if OK */
-	return status;
+        VL53LX_Error status = VL53LX_ERROR_NONE;
+        if (HAL_I2C_Mem_Write(&hi2c1, pdev->i2c_slave_address, index,
+                              I2C_MEMADD_SIZE_16BIT, pdata, count,
+                              HAL_MAX_DELAY) != HAL_OK) {
+                status = VL53LX_ERROR_CONTROL_INTERFACE;
+        }
+        return status;
 }
 
 
 VL53LX_Error VL53LX_ReadMulti(
-	VL53LX_Dev_t *pdev,
-	uint16_t      index,
-	uint8_t      *pdata,
-	uint32_t      count)
+        VL53LX_Dev_t *pdev,
+        uint16_t      index,
+        uint8_t      *pdata,
+        uint32_t      count)
 {
-	VL53LX_Error status = 255;
-	/* To be filled by customer according to the platform request. Return 0 if OK */
-	return status;
+        VL53LX_Error status = VL53LX_ERROR_NONE;
+        if (HAL_I2C_Mem_Read(&hi2c1, pdev->i2c_slave_address, index,
+                             I2C_MEMADD_SIZE_16BIT, pdata, count,
+                             HAL_MAX_DELAY) != HAL_OK) {
+                status = VL53LX_ERROR_CONTROL_INTERFACE;
+        }
+        return status;
 }
 
 
@@ -194,39 +205,45 @@ VL53LX_Error VL53LX_RdDWord(
 
 
 VL53LX_Error VL53LX_WaitUs(
-	VL53LX_Dev_t *pdev,
-	int32_t       wait_us)
+        VL53LX_Dev_t *pdev,
+        int32_t       wait_us)
 {
-	VL53LX_Error status = 255;
-	/* To be filled by customer according to the platform request. Return 0 if OK */
-	return status;
+        VL53LX_Error status = VL53LX_ERROR_NONE;
+        (void)pdev;
+        uint32_t count = (SystemCoreClock / 1000000) * (uint32_t)wait_us / 5U;
+        while (count--)
+        {
+                __NOP();
+        }
+        return status;
 }
 
 
 VL53LX_Error VL53LX_WaitMs(
-	VL53LX_Dev_t *pdev,
-	int32_t       wait_ms)
+        VL53LX_Dev_t *pdev,
+        int32_t       wait_ms)
 {
-	VL53LX_Error status = 255;
-	/* To be filled by customer according to the platform request. Return 0 if OK */
-	return status;
+        VL53LX_Error status = VL53LX_ERROR_NONE;
+        (void)pdev;
+        HAL_Delay(wait_ms);
+        return status;
 }
 
 
 
 VL53LX_Error VL53LX_GetTimerFrequency(int32_t *ptimer_freq_hz)
 {
-	VL53LX_Error status = 255;
-	/* To be filled by customer according to the platform request. Return 0 if OK */
-	return status;
+        VL53LX_Error status = VL53LX_ERROR_NONE;
+        *ptimer_freq_hz = 1000;
+        return status;
 }
 
 
 VL53LX_Error VL53LX_GetTimerValue(int32_t *ptimer_count)
 {
-	VL53LX_Error status = 255;
-	/* To be filled by customer according to the platform request. Return 0 if OK */
-	return status;
+        VL53LX_Error status = VL53LX_ERROR_NONE;
+        *ptimer_count = (int32_t)HAL_GetTick();
+        return status;
 }
 
 
@@ -234,89 +251,77 @@ VL53LX_Error VL53LX_GetTimerValue(int32_t *ptimer_count)
 
 VL53LX_Error VL53LX_GpioSetMode(uint8_t pin, uint8_t mode)
 {
-	VL53LX_Error status = 255;
-	/* To be filled by customer according to the platform request. Return 0 if OK */
-	return status;
+        (void)pin;
+        (void)mode;
+        return VL53LX_ERROR_NONE;
 }
 
 
 VL53LX_Error  VL53LX_GpioSetValue(uint8_t pin, uint8_t value)
 {
-	VL53LX_Error status = 255;
-	/* To be filled by customer according to the platform request. Return 0 if OK */
-	return status;
+        (void)pin;
+        (void)value;
+        return VL53LX_ERROR_NONE;
 
 }
 
 
 VL53LX_Error  VL53LX_GpioGetValue(uint8_t pin, uint8_t *pvalue)
 {
-	VL53LX_Error status = 255;
-	/* To be filled by customer according to the platform request. Return 0 if OK */
-	return status;
+        (void)pin;
+        *pvalue = 0;
+        return VL53LX_ERROR_NONE;
 }
 
 
 
 VL53LX_Error  VL53LX_GpioXshutdown(uint8_t value)
 {
-	VL53LX_Error status = 255;
-	/* To be filled by customer according to the platform request. Return 0 if OK */
-	return status;
+        (void)value;
+        return VL53LX_ERROR_NONE;
 }
 
 
 VL53LX_Error  VL53LX_GpioCommsSelect(uint8_t value)
 {
-	VL53LX_Error status = 255;
-	/* To be filled by customer according to the platform request. Return 0 if OK */
-	return status;
+        (void)value;
+        return VL53LX_ERROR_NONE;
 }
 
 
 VL53LX_Error  VL53LX_GpioPowerEnable(uint8_t value)
 {
-	VL53LX_Error status = 255;
-	/* To be filled by customer according to the platform request. Return 0 if OK */
-	return status;
+        (void)value;
+        return VL53LX_ERROR_NONE;
 }
 
 
 VL53LX_Error  VL53LX_GpioInterruptEnable(void (*function)(void), uint8_t edge_type)
 {
-	VL53LX_Error status = 255;
-	/* To be filled by customer according to the platform request. Return 0 if OK */
-	return status;
+        (void)function;
+        (void)edge_type;
+        return VL53LX_ERROR_NONE;
 }
 
 
 VL53LX_Error  VL53LX_GpioInterruptDisable(void)
 {
-	VL53LX_Error status = 255;
-	/* To be filled by customer according to the platform request. Return 0 if OK */
-	return status;
+        return VL53LX_ERROR_NONE;
 }
 
 
 VL53LX_Error VL53LX_GetTickCount(
-		VL53LX_Dev_t *pdev,
-		uint32_t *ptick_count_ms)
+                VL53LX_Dev_t *pdev,
+                uint32_t *ptick_count_ms)
 {
-
-
-
-	VL53LX_Error status = 255;
-	(void) pdev;
-
-	
-	/* To be filled by customer according to the platform request. Return 0 if OK */
-	/* example: *ptick_count_ms = timeGetTime();   */
-	trace_print(
-	VL53LX_TRACE_LEVEL_DEBUG,
-	"VL53LX_GetTickCount() = %5u ms;\n",
-	*ptick_count_ms);
-
-	return status;
+        VL53LX_Error status = VL53LX_ERROR_NONE;
+        (void)pdev;
+        *ptick_count_ms = HAL_GetTick();
+        trace_print(
+        VL53LX_TRACE_LEVEL_DEBUG,
+        "VL53LX_GetTickCount() = %5u ms;\n",
+        *ptick_count_ms);
+        return status;
 
 }
 


### PR DESCRIPTION
## Summary
- Implement VL53L4CX platform hooks for STM32 HAL, adding I2C read/write, delays, timer helpers, and stub GPIO handlers.
- Add UART printf support and a simple continuous ranging loop using VL53L4CX API.

## Testing
- ⚠️ `make -C VBN_TOF_TESTING/Debug` *(fails: Drivers/VL53L4CX_BareDriver_1.2.14/BareDriver/platform/src/vl53lx_platform.d:1: *** multiple target patterns. Stop.)*

------
https://chatgpt.com/codex/tasks/task_e_68ade8d37be08325bca28d1e2e24a12c